### PR TITLE
[Critical] Added msg.sender check to staking function of Scales Contract

### DIFF
--- a/contracts/Scales.sol
+++ b/contracts/Scales.sol
@@ -19,6 +19,7 @@ error Scales_InvalidTokenAmount();
 error Scales_NotApprovedForAll();
 error Scales_NothingToWithdraw();
 error Scales_TokenNotStranded();
+error Scales_YouDontOwnTheseTokens();
 
 /**                                     ..',,;;;;:::;;;,,'..
                                  .';:ccccc:::;;,,,,,;;;:::ccccc:;'.
@@ -238,6 +239,9 @@ contract Scales is IScales, ERC20, ERC721Holder, AccessControl, Pausable, Reentr
         uint16 genesisCount;
         for (uint256 i; i < tokenIds.length; i++) {
             uint256 tokenId = tokenIds[i];
+            
+            // Check msg.sender is owner of tokenId staked in contract
+            if ( tokenOwners[tokenId] != _msgSender() ) revert Scales_YouDontOwnTheseTokens();
 
             KAIJU.safeTransferFrom(_msgSender(), address(this), tokenId);
             tokenOwners[tokenId] = _msgSender();

--- a/contracts/Scales.sol
+++ b/contracts/Scales.sol
@@ -19,7 +19,7 @@ error Scales_InvalidTokenAmount();
 error Scales_NotApprovedForAll();
 error Scales_NothingToWithdraw();
 error Scales_TokenNotStranded();
-error Scales_YouDontOwnTheseTokens();
+error Scales_SenderNotTokenOwner();
 
 /**                                     ..',,;;;;:::;;;,,'..
                                  .';:ccccc:::;;,,,,,;;;:::ccccc:;'.
@@ -241,7 +241,7 @@ contract Scales is IScales, ERC20, ERC721Holder, AccessControl, Pausable, Reentr
             uint256 tokenId = tokenIds[i];
             
             // Check msg.sender is owner of tokenId staked in contract
-            if ( tokenOwners[tokenId] != _msgSender() ) revert Scales_YouDontOwnTheseTokens();
+            if ( tokenOwners[tokenId] != _msgSender() ) revert Scales_SenderNotTokenOwner();
 
             KAIJU.safeTransferFrom(_msgSender(), address(this), tokenId);
             tokenOwners[tokenId] = _msgSender();


### PR DESCRIPTION
Current issue is that attackers can stake owners tokens without their permission. There is no check in the staking function of the scales contract to prevent this from happening.

```Solidity
/**
     * @notice Stake KAIJU tokens and start earning $SCALES
     * @param tokenIds KAIJU tokens to stake
     */
    function stake(uint256[] memory tokenIds) public whenNotPaused nonReentrant {
        if (tokenIds.length == 0 || tokenIds.length > MAX_PER_TX) revert Scales_InvalidTokenAmount();

        _update(_msgSender());

        uint16 genesisCount;
        for (uint256 i; i < tokenIds.length; i++) {
            uint256 tokenId = tokenIds[i];

            KAIJU.safeTransferFrom(_msgSender(), address(this), tokenId);
            tokenOwners[tokenId] = _msgSender();

            if (tokenId < KAIJU_GENESIS_SUPPLY) genesisCount += 1;

            emit Stake(tokenId, _msgSender());
        }

        accountInfo[_msgSender()].shares += uint16(tokenIds.length + (genesisCount * GENESIS_BONUS));
    }
```

This pull request adds the owner check 